### PR TITLE
Fix chat tool_calls validation bug and redesign UI to be Claude-like

### DIFF
--- a/app/models/chat/message.rb
+++ b/app/models/chat/message.rb
@@ -61,7 +61,7 @@ class Chat::Message < ApplicationRecord
   private
 
   def content_or_images_present
-    return if content.present? || images.attached?
+    return if content.present? || images.attached? || tool_calls.present? || tool_call_id.present?
 
     errors.add(:base, "Message can't be blank")
   end

--- a/app/views/chat/_anon_input_form.html.erb
+++ b/app/views/chat/_anon_input_form.html.erb
@@ -1,16 +1,16 @@
 <%= form_with url: create_message_chat_path, id: "chat_input_form", data: { chat_target: "form", action: "submit->chat#send" } do |f| %>
-  <div class="flex items-end gap-2 rounded-2xl border border-stone-200 bg-white px-3 py-2 shadow-sm focus-within:border-amber-300 focus-within:ring-2 focus-within:ring-amber-200/60">
+  <div class="flex items-end gap-2 rounded-2xl border border-stone-200 bg-white px-3 py-2 shadow-sm transition focus-within:border-stone-300 focus-within:shadow-md">
     <textarea
       name="content"
       rows="1"
-      placeholder="Ask about recipes..."
-      class="max-h-40 min-h-[36px] flex-1 resize-none border-0 bg-transparent py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-0"
+      placeholder="Message Stovaro..."
+      class="max-h-40 min-h-[36px] flex-1 resize-none border-0 bg-transparent py-2 text-[0.9rem] text-stone-800 placeholder:text-stone-400 focus:outline-none focus:ring-0"
       data-chat-target="input"
       data-action="keydown->chat#handleKeydown input->chat#autoResize"
     ></textarea>
 
     <button type="submit"
-            class="mb-0.5 flex h-9 w-9 flex-none items-center justify-center rounded-lg bg-slate-900 text-white transition hover:bg-slate-800 disabled:opacity-30"
+            class="mb-0.5 flex h-8 w-8 flex-none items-center justify-center rounded-lg bg-stone-800 text-white transition hover:bg-stone-700 disabled:bg-stone-300 disabled:text-stone-500"
             data-chat-target="submit">
       <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 10.5L12 3m0 0l7.5 7.5M12 3v18" />

--- a/app/views/chat/_conversation_sidebar.html.erb
+++ b/app/views/chat/_conversation_sidebar.html.erb
@@ -1,19 +1,19 @@
-<aside id="chat_sidebar" class="flex h-full flex-col overflow-hidden bg-slate-950 text-slate-100 lg:rounded-2xl lg:ring-1 lg:ring-slate-800">
-  <div class="border-b border-white/10 px-4 pb-3 pt-4">
-    <div class="flex items-center justify-between">
-      <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Chats</p>
-      <button type="button"
-              class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition hover:bg-white/10 hover:text-white lg:hidden"
-              data-action="click->chat#toggleSidebar">
-        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
+<aside id="chat_sidebar" class="flex h-full flex-col overflow-hidden bg-stone-50 lg:bg-stone-50/80">
+  <div class="flex items-center justify-between border-b border-stone-200/80 px-4 pb-3 pt-4">
+    <p class="text-xs font-semibold uppercase tracking-widest text-stone-400">Chats</p>
+    <button type="button"
+            class="flex h-8 w-8 items-center justify-center rounded-lg text-stone-400 transition hover:bg-stone-200 hover:text-stone-600 lg:hidden"
+            data-action="click->chat#toggleSidebar">
+      <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  </div>
 
+  <div class="px-3 pt-3">
     <%= button_to create_conversation_chat_path,
         method: :post,
-        class: "mt-3 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-white/10" do %>
+        class: "inline-flex w-full items-center justify-center gap-2 rounded-xl border border-stone-200 bg-white px-4 py-2.5 text-sm font-medium text-stone-700 shadow-sm transition hover:bg-stone-50 hover:shadow" do %>
       <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
       </svg>
@@ -22,35 +22,35 @@
   </div>
 
   <div class="flex-1 overflow-y-auto px-2 py-2">
-    <div class="space-y-1">
+    <div class="space-y-0.5">
       <% conversations.each do |conversation| %>
         <% active = conversation == current_conversation %>
         <div class="group">
           <%= link_to chat_conversation_path(conversation),
               class: [
                 "block rounded-xl px-3 py-2.5 transition",
-                active ? "bg-white/10" : "hover:bg-white/5"
+                active ? "bg-white shadow-sm ring-1 ring-stone-200/60" : "hover:bg-white/60"
               ].join(" ") do %>
-            <p class="<%= active ? 'text-white' : 'text-slate-300' %> truncate text-sm font-medium"><%= conversation.display_title %></p>
-            <p class="mt-0.5 truncate text-xs <%= active ? 'text-slate-400' : 'text-slate-500' %>">
-              <%= conversation.preview_text.presence || "Empty" %>
+            <p class="<%= active ? 'text-stone-900' : 'text-stone-600' %> truncate text-sm font-medium"><%= conversation.display_title %></p>
+            <p class="mt-0.5 truncate text-xs text-stone-400">
+              <%= conversation_timestamp_label(conversation) %>
             </p>
           <% end %>
 
           <% if active %>
-            <div class="mx-2 mt-1 flex items-center gap-1.5 rounded-lg border border-white/5 bg-white/5 p-1.5">
+            <div class="mx-1 mt-1 flex items-center gap-1.5 rounded-lg border border-stone-200 bg-white p-1.5">
               <%= form_with url: update_chat_conversation_path(conversation), method: :patch, class: "flex flex-1 items-center gap-1.5" do %>
                 <%= text_field_tag :title,
                     conversation.display_title,
-                    class: "h-8 flex-1 rounded-lg border-0 bg-white/5 px-2 text-xs text-white placeholder:text-slate-500 focus:outline-none focus:ring-1 focus:ring-amber-300/30" %>
-                <%= submit_tag "Rename", class: "h-8 rounded-lg bg-white/10 px-2.5 text-xs font-medium text-white transition hover:bg-white/20" %>
+                    class: "h-7 flex-1 rounded-md border border-stone-200 bg-stone-50 px-2 text-xs text-stone-800 placeholder:text-stone-400 focus:border-amber-300 focus:outline-none focus:ring-1 focus:ring-amber-200" %>
+                <%= submit_tag "Rename", class: "h-7 rounded-md bg-stone-100 px-2.5 text-xs font-medium text-stone-600 transition hover:bg-stone-200 cursor-pointer" %>
               <% end %>
 
               <%= button_to destroy_chat_conversation_path(conversation),
                   method: :delete,
                   form: { data: { turbo_confirm: "Delete this chat?" } },
-                  class: "flex h-8 w-8 flex-none items-center justify-center rounded-lg text-red-400 transition hover:bg-red-500/10" do %>
-                <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  class: "flex h-7 w-7 flex-none items-center justify-center rounded-md text-stone-400 transition hover:bg-red-50 hover:text-red-500" do %>
+                <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                 </svg>
               <% end %>

--- a/app/views/chat/_empty_state.html.erb
+++ b/app/views/chat/_empty_state.html.erb
@@ -1,33 +1,37 @@
-<div class="flex flex-1 flex-col items-center justify-center py-12 text-center" data-chat-target="emptyState">
-  <div class="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-amber-100 to-orange-100">
-    <svg class="h-7 w-7 text-amber-600" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+<div class="flex flex-1 flex-col items-center justify-center px-4 py-16 text-center" data-chat-target="emptyState">
+  <div class="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-amber-400 to-orange-400 shadow-md">
+    <svg class="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
     </svg>
   </div>
-  <h2 class="mt-4 text-base font-semibold text-slate-900"><%= Current.user&.admin? ? "What should I create?" : "What are you in the mood for?" %></h2>
-  <p class="mt-1.5 max-w-sm text-sm text-slate-500">
-    <%= Current.user&.admin? ? "Generate recipes, create categories, and publish content with AI imagery." : "Search recipes, get suggestions, or plan what to cook." %>
+  <h2 class="mt-5 text-lg font-semibold text-stone-800"><%= Current.user&.admin? ? "What should I create?" : "What are you in the mood for?" %></h2>
+  <p class="mt-2 max-w-md text-sm leading-relaxed text-stone-500">
+    <%= Current.user&.admin? ? "Generate recipes, create categories, and publish content with AI imagery." : "I can search recipes, check your favorites, suggest meals, or help you plan what to cook." %>
   </p>
-  <div class="mt-5 flex flex-wrap justify-center gap-2">
+
+  <div class="mt-8 grid gap-3 sm:grid-cols-3">
     <% suggestions = if Current.user&.admin?
       [
-        "Preview a vegan sheet-pan dinner with crispy tofu and chili crisp.",
-        "Create and publish a cozy dairy-free soup recipe for weeknights.",
-        "Show me the latest seed runs and which ones still need review."
+        { text: "Preview a vegan sheet-pan dinner", icon: "M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" },
+        { text: "Publish a dairy-free soup recipe", icon: "M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" },
+        { text: "Show me recent seed runs", icon: "M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z" }
       ]
     else
       [
-        "What's trending right now?",
-        "Suggest something based on my favorites",
-        "Easy weeknight dinners"
+        { text: "What's trending right now?", icon: "M15.362 5.214A8.252 8.252 0 0112 21 8.25 8.25 0 016.038 7.048 8.287 8.287 0 009 9.6a8.983 8.983 0 013.361-6.867 8.21 8.21 0 003 2.48z" },
+        { text: "Suggest something from my favorites", icon: "M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" },
+        { text: "Easy weeknight dinners", icon: "M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" }
       ]
     end %>
     <% suggestions.each do |suggestion| %>
       <button type="button"
-              class="rounded-full border border-stone-200 bg-white px-3.5 py-2 text-xs text-slate-600 shadow-sm transition hover:border-amber-300 hover:bg-amber-50 sm:text-sm"
+              class="group flex flex-col items-center rounded-2xl border border-stone-200 bg-white px-5 py-4 text-left shadow-sm transition hover:border-stone-300 hover:shadow-md"
               data-action="click->chat#fillSuggestion"
-              data-suggestion="<%= suggestion %>">
-        <%= suggestion %>
+              data-suggestion="<%= suggestion[:text] %>">
+        <svg class="h-5 w-5 text-stone-400 transition group-hover:text-amber-500" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="<%= suggestion[:icon] %>" />
+        </svg>
+        <span class="mt-2.5 text-sm font-medium text-stone-600 transition group-hover:text-stone-800"><%= suggestion[:text] %></span>
       </button>
     <% end %>
   </div>

--- a/app/views/chat/_header.html.erb
+++ b/app/views/chat/_header.html.erb
@@ -1,9 +1,9 @@
 <% active_conversation = local_assigns[:conversation] %>
 
-<div id="chat_header" class="flex items-center gap-3 border-b border-stone-200 bg-stone-50/80 px-4 py-3 sm:px-6">
+<div id="chat_header" class="flex items-center gap-3 border-b border-stone-100 px-4 py-3 sm:px-6">
   <% if Current.user&.pro? || Current.user&.admin? %>
     <button type="button"
-            class="flex h-9 w-9 flex-none items-center justify-center rounded-lg text-slate-500 transition hover:bg-stone-100 hover:text-slate-700 lg:hidden"
+            class="flex h-8 w-8 flex-none items-center justify-center rounded-lg text-stone-400 transition hover:bg-stone-100 hover:text-stone-600 lg:hidden"
             data-action="click->chat#toggleSidebar"
             title="Open chats">
       <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -12,15 +12,15 @@
     </button>
   <% end %>
 
-  <div class="flex h-9 w-9 flex-none items-center justify-center rounded-xl bg-amber-100 text-amber-700">
-    <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <div class="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-gradient-to-br from-amber-400 to-orange-400">
+    <svg class="h-4 w-4 text-white" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
     </svg>
   </div>
   <div class="min-w-0 flex-1">
-    <h1 class="truncate text-sm font-semibold text-slate-900"><%= Current.user&.admin? ? "Seed Copilot" : "Recipe Chat" %></h1>
-    <p class="truncate text-xs text-slate-500">
-      <%= active_conversation&.display_title || (Current.user&.admin? ? "Preview and publish recipes from chat." : "Ask about recipes, get suggestions") %>
+    <h1 class="truncate text-sm font-medium text-stone-800"><%= Current.user&.admin? ? "Seed Copilot" : "Recipe Chat" %></h1>
+    <p class="truncate text-xs text-stone-400">
+      <%= active_conversation&.display_title || (Current.user&.admin? ? "Preview and publish recipes from chat." : "Discover recipes, plan meals, get cooking help") %>
     </p>
   </div>
 </div>

--- a/app/views/chat/_input_form.html.erb
+++ b/app/views/chat/_input_form.html.erb
@@ -14,32 +14,32 @@
 
   <div class="hidden flex-wrap gap-2 pb-2" data-chat-target="attachmentPreview"></div>
 
-  <div class="flex items-end gap-2 rounded-2xl border border-stone-200 bg-white px-3 py-2 shadow-sm focus-within:border-amber-300 focus-within:ring-2 focus-within:ring-amber-200/60">
+  <div class="flex items-end gap-2 rounded-2xl border border-stone-200 bg-white px-3 py-2 shadow-sm transition focus-within:border-stone-300 focus-within:shadow-md">
     <button type="button"
-            class="mb-0.5 flex h-9 w-9 flex-none items-center justify-center rounded-lg text-slate-400 transition hover:bg-stone-100 hover:text-slate-600"
+            class="mb-0.5 flex h-8 w-8 flex-none items-center justify-center rounded-lg text-stone-400 transition hover:bg-stone-100 hover:text-stone-600"
             data-action="click->chat#openFilePicker"
             title="Attach images">
-      <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M18.375 12.739l-7.693 7.693a3 3 0 11-4.243-4.243l8.308-8.308a2 2 0 112.828 2.828l-8.308 8.308a1 1 0 11-1.414-1.414l7.693-7.693" />
+      <svg class="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0 0 22.5 18.75V5.25A2.25 2.25 0 0 0 20.25 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21Z" />
       </svg>
     </button>
 
     <textarea
       name="content"
       rows="1"
-      placeholder="Ask about recipes..."
-      class="max-h-40 min-h-[36px] flex-1 resize-none border-0 bg-transparent py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-0"
+      placeholder="Message Stovaro..."
+      class="max-h-40 min-h-[36px] flex-1 resize-none border-0 bg-transparent py-2 text-[0.9rem] text-stone-800 placeholder:text-stone-400 focus:outline-none focus:ring-0"
       data-chat-target="input"
       data-action="keydown->chat#handleKeydown input->chat#autoResize"
     ></textarea>
 
     <button type="submit"
-            class="mb-0.5 flex h-9 w-9 flex-none items-center justify-center rounded-lg bg-slate-900 text-white transition hover:bg-slate-800 disabled:opacity-30"
+            class="mb-0.5 flex h-8 w-8 flex-none items-center justify-center rounded-lg bg-stone-800 text-white transition hover:bg-stone-700 disabled:bg-stone-300 disabled:text-stone-500"
             data-chat-target="submit">
       <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 10.5L12 3m0 0l7.5 7.5M12 3v18" />
       </svg>
     </button>
   </div>
-  <p class="mt-1.5 px-1 text-center text-[11px] text-slate-400">Upload up to 3 photos. Enter to send, Shift+Enter for new line.</p>
+  <p class="mt-1.5 text-center text-[11px] text-stone-400">Enter to send, Shift+Enter for new line</p>
 <% end %>

--- a/app/views/chat/_message.html.erb
+++ b/app/views/chat/_message.html.erb
@@ -2,30 +2,32 @@
   <div class="flex justify-end">
     <div class="max-w-[85%] space-y-2 sm:max-w-[75%]">
       <% if message.content.present? %>
-        <div class="rounded-2xl rounded-tr-sm bg-slate-900 px-4 py-2.5 text-sm leading-relaxed text-white">
+        <div class="rounded-3xl rounded-br-lg bg-stone-100 px-5 py-3 text-[0.9rem] leading-relaxed text-slate-800">
           <%= simple_format(message.content, {}, wrapper_tag: "span") %>
         </div>
       <% end %>
 
       <% if message.images.attached? %>
-        <div class="grid gap-2 <%= message.images.many? ? 'grid-cols-2' : 'grid-cols-1' %>">
+        <div class="flex flex-wrap justify-end gap-2">
           <% message.images.each do |image| %>
-            <%= image_tag image, class: "max-h-56 w-full rounded-2xl border border-stone-200 object-cover" %>
+            <%= image_tag image, class: "max-h-56 rounded-2xl object-cover", loading: "lazy" %>
           <% end %>
         </div>
       <% end %>
     </div>
   </div>
 <% elsif message.assistant? %>
-  <div class="flex items-start gap-3">
-    <div class="flex h-7 w-7 flex-none items-center justify-center rounded-full bg-amber-100 text-amber-700">
-      <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
-      </svg>
-    </div>
-    <div class="min-w-0 flex-1 text-sm leading-relaxed text-slate-700">
-      <div class="prose prose-sm prose-slate max-w-none prose-a:text-amber-700 prose-a:underline prose-a:decoration-amber-300 prose-img:my-3 prose-img:rounded-xl prose-img:border prose-img:border-stone-200">
-        <%= sanitize(render_markdown(message.content), tags: %w[p a strong em ul ol li br h3 h4 code pre img], attributes: %w[href class src alt loading]) %>
+  <div class="group">
+    <div class="flex items-start gap-3.5">
+      <div class="mt-0.5 flex h-7 w-7 flex-none items-center justify-center rounded-full bg-gradient-to-br from-amber-400 to-orange-400">
+        <svg class="h-3.5 w-3.5 text-white" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+        </svg>
+      </div>
+      <div class="min-w-0 flex-1 text-[0.9rem] leading-relaxed text-slate-700">
+        <div class="prose prose-sm prose-slate max-w-none prose-headings:text-slate-800 prose-p:my-2 prose-a:text-amber-700 prose-a:no-underline hover:prose-a:underline prose-code:rounded prose-code:bg-stone-100 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-sm prose-code:before:content-[''] prose-code:after:content-[''] prose-pre:rounded-xl prose-pre:bg-stone-50 prose-pre:ring-1 prose-pre:ring-stone-200 prose-img:my-4 prose-img:rounded-2xl prose-img:shadow-sm prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5">
+          <%= sanitize(render_markdown(message.content), tags: %w[p a strong em ul ol li br h3 h4 code pre img], attributes: %w[href class src alt loading]) %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/chat/_mock_conversation.html.erb
+++ b/app/views/chat/_mock_conversation.html.erb
@@ -1,22 +1,24 @@
-<div class="flex flex-col px-6 py-8">
-  <div class="flex items-start gap-3">
-    <div class="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-amber-100 text-amber-700">
-      <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" /></svg>
+<div class="mx-auto max-w-3xl space-y-6 px-6 py-8">
+  <div class="flex items-start gap-3.5">
+    <div class="mt-0.5 flex h-7 w-7 flex-none items-center justify-center rounded-full bg-gradient-to-br from-amber-400 to-orange-400">
+      <svg class="h-3.5 w-3.5 text-white" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" /></svg>
     </div>
-    <div class="rounded-2xl rounded-tl-md bg-stone-100 px-4 py-3 text-sm text-slate-700">
+    <div class="text-[0.9rem] leading-relaxed text-stone-700">
       Hey! I found a few recipes you might love based on your favorites. Here are some easy weeknight dinners...
     </div>
   </div>
-  <div class="mt-4 flex justify-end">
-    <div class="rounded-2xl rounded-tr-md bg-slate-900 px-4 py-3 text-sm text-white">
+
+  <div class="flex justify-end">
+    <div class="rounded-3xl rounded-br-lg bg-stone-100 px-5 py-3 text-[0.9rem] leading-relaxed text-stone-800">
       That sounds great! What about something with chicken?
     </div>
   </div>
-  <div class="mt-4 flex items-start gap-3">
-    <div class="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-amber-100 text-amber-700">
-      <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" /></svg>
+
+  <div class="flex items-start gap-3.5">
+    <div class="mt-0.5 flex h-7 w-7 flex-none items-center justify-center rounded-full bg-gradient-to-br from-amber-400 to-orange-400">
+      <svg class="h-3.5 w-3.5 text-white" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" /></svg>
     </div>
-    <div class="rounded-2xl rounded-tl-md bg-stone-100 px-4 py-3 text-sm text-slate-700">
+    <div class="text-[0.9rem] leading-relaxed text-stone-700">
       I found 3 great chicken recipes under 30 minutes. Let me pull those up for you...
     </div>
   </div>

--- a/app/views/chat/create_message.turbo_stream.erb
+++ b/app/views/chat/create_message.turbo_stream.erb
@@ -3,16 +3,16 @@
 <% end %>
 
 <%= turbo_stream.append "chat_messages_inner" do %>
-  <div id="chat_thinking" class="flex items-start gap-3">
-    <div class="flex h-7 w-7 flex-none items-center justify-center rounded-full bg-amber-100 text-amber-700">
-      <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+  <div id="chat_thinking" class="flex items-start gap-3.5">
+    <div class="mt-0.5 flex h-7 w-7 flex-none items-center justify-center rounded-full bg-gradient-to-br from-amber-400 to-orange-400">
+      <svg class="h-3.5 w-3.5 text-white" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
       </svg>
     </div>
-    <div class="flex items-center gap-1.5 rounded-2xl bg-stone-100 px-4 py-3">
-      <span class="h-1.5 w-1.5 animate-bounce rounded-full bg-stone-400" style="animation-delay: 0ms"></span>
-      <span class="h-1.5 w-1.5 animate-bounce rounded-full bg-stone-400" style="animation-delay: 150ms"></span>
-      <span class="h-1.5 w-1.5 animate-bounce rounded-full bg-stone-400" style="animation-delay: 300ms"></span>
+    <div class="flex items-center gap-1 py-2">
+      <span class="h-1.5 w-1.5 animate-bounce rounded-full bg-stone-300" style="animation-delay: 0ms"></span>
+      <span class="h-1.5 w-1.5 animate-bounce rounded-full bg-stone-300" style="animation-delay: 150ms"></span>
+      <span class="h-1.5 w-1.5 animate-bounce rounded-full bg-stone-300" style="animation-delay: 300ms"></span>
     </div>
   </div>
 <% end %>

--- a/app/views/chat/show.html.erb
+++ b/app/views/chat/show.html.erb
@@ -4,27 +4,27 @@
 <div class="w-full">
   <div class="mx-auto max-w-7xl px-0 sm:px-6 lg:px-8">
     <% if Current.user&.pro? || Current.user&.admin? %>
-      <div class="relative flex h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-7rem)]" data-controller="chat">
+      <div class="relative flex h-[calc(100dvh-6rem)] overflow-hidden rounded-none border-stone-200 bg-white sm:h-[calc(100dvh-7rem)] sm:rounded-2xl sm:border sm:shadow-sm" data-controller="chat">
         <%# Mobile sidebar backdrop %>
-        <div class="fixed inset-0 z-30 hidden bg-black/50 backdrop-blur-sm transition-opacity"
+        <div class="fixed inset-0 z-30 hidden bg-black/30 backdrop-blur-sm transition-opacity"
              data-chat-target="sidebarBackdrop"
              data-action="click->chat#toggleSidebar"></div>
 
         <%# Sidebar: drawer on mobile, static on desktop %>
-        <div class="fixed inset-y-0 left-0 z-40 w-[280px] -translate-x-full transition-transform duration-300 ease-in-out lg:relative lg:z-auto lg:w-[300px] lg:translate-x-0 lg:transition-none"
+        <div class="fixed inset-y-0 left-0 z-40 w-[280px] -translate-x-full border-r border-stone-200 bg-stone-50 transition-transform duration-300 ease-in-out lg:relative lg:z-auto lg:w-[280px] lg:translate-x-0 lg:transition-none"
              data-chat-target="sidebar">
           <%= render "chat/conversation_sidebar", conversations: @conversations, current_conversation: @conversation %>
         </div>
 
         <%# Main chat area %>
-        <div class="flex min-w-0 flex-1 flex-col">
+        <div class="flex min-w-0 flex-1 flex-col bg-white">
           <%= render "chat/header", conversation: @conversation %>
 
           <%= turbo_stream_from @conversation %>
           <div id="chat_messages"
-               class="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 sm:px-6"
+               class="min-h-0 flex-1 overflow-y-auto overscroll-contain"
                data-chat-target="messages">
-            <div id="chat_messages_inner" class="mx-auto max-w-3xl space-y-5 py-4">
+            <div id="chat_messages_inner" class="mx-auto max-w-3xl space-y-6 px-4 py-6 sm:px-6">
               <% if @messages.empty? %>
                 <%= render "chat/empty_state" %>
               <% else %>
@@ -35,7 +35,7 @@
             </div>
           </div>
 
-          <div class="border-t border-stone-200 bg-stone-50 px-4 pb-3 pt-3 sm:px-6 sm:pb-4">
+          <div class="border-t border-stone-100 px-4 pb-4 pt-3 sm:px-6">
             <div class="mx-auto max-w-3xl">
               <%= render "chat/input_form", conversation: @conversation %>
             </div>
@@ -51,32 +51,32 @@
         </div>
         <div class="absolute inset-0 flex items-center justify-center bg-white/70 backdrop-blur-sm">
           <div class="mx-4 max-w-md rounded-3xl border border-stone-200 bg-white px-8 py-10 text-center shadow-2xl">
-            <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-amber-400 to-orange-500 shadow-lg">
+            <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-amber-400 to-orange-400 shadow-lg">
               <svg class="h-7 w-7 text-white" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
               </svg>
             </div>
-            <h2 class="mt-5 text-xl font-semibold text-slate-900">Recipe Chat is a Pro feature</h2>
-            <p class="mt-3 text-sm text-slate-600">Get personalized recipe suggestions, search the entire catalog, and explore your taste profile with AI — all in a conversation.</p>
-            <%= link_to "Upgrade to #{Billing::PlanCatalog::PRO_DISPLAY_NAME}", pricing_path, class: "mt-6 inline-flex items-center rounded-xl bg-slate-900 px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800" %>
+            <h2 class="mt-5 text-xl font-semibold text-stone-800">Recipe Chat is a Pro feature</h2>
+            <p class="mt-3 text-sm leading-relaxed text-stone-500">Get personalized recipe suggestions, search the entire catalog, and explore your taste profile with AI.</p>
+            <%= link_to "Upgrade to #{Billing::PlanCatalog::PRO_DISPLAY_NAME}", pricing_path, class: "mt-6 inline-flex items-center rounded-xl bg-stone-800 px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-stone-700" %>
           </div>
         </div>
       </div>
 
     <% else %>
       <%# === ANONYMOUS: Interactive teaser === %>
-      <div class="flex h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-7rem)] flex-col" data-controller="chat">
+      <div class="flex h-[calc(100dvh-6rem)] flex-col overflow-hidden rounded-none bg-white sm:h-[calc(100dvh-7rem)] sm:rounded-2xl sm:border sm:border-stone-200 sm:shadow-sm" data-controller="chat">
         <%= render "chat/header" %>
 
         <div id="chat_messages"
-             class="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 sm:px-6"
+             class="min-h-0 flex-1 overflow-y-auto overscroll-contain"
              data-chat-target="messages">
-          <div id="chat_messages_inner" class="mx-auto max-w-3xl space-y-5 py-4">
+          <div id="chat_messages_inner" class="mx-auto max-w-3xl space-y-6 px-4 py-6 sm:px-6">
             <%= render "chat/empty_state" %>
           </div>
         </div>
 
-        <div class="border-t border-stone-200 bg-stone-50 px-4 pb-3 pt-3 sm:px-6 sm:pb-4">
+        <div class="border-t border-stone-100 px-4 pb-4 pt-3 sm:px-6">
           <div class="mx-auto max-w-3xl">
             <%= render "chat/anon_input_form" %>
           </div>


### PR DESCRIPTION
Bug fix: Assistant messages with tool_calls but nil content were failing the content_or_images_present validation, causing "Message can't be blank" errors. Now allows messages with tool_calls or tool_call_id to pass.

UI redesign: Shifted from dark sidebar + bubble messages to a clean, minimal Claude-inspired interface:
- Light stone-50 sidebar with subtle card-style active states
- Flowing assistant text without heavy bubbles (gradient amber icon)
- Softer user message pills with stone-100 background
- Clean input bar with shadow elevation on focus
- Card-style suggestion grid in empty state
- Consistent warm amber/orange accent throughout
- Refined typography with 0.9rem base size

https://claude.ai/code/session_01Jy5Vk12ureT4rGZaxy481Q